### PR TITLE
chore: close out the /code-review sub-80 cleanups

### DIFF
--- a/PORT_CONTRACT.md
+++ b/PORT_CONTRACT.md
@@ -7,7 +7,7 @@ Cross-slice interfaces for porting cc-autodream to OMP. All slices agree on thes
 - Never invoke `claude` in the OMP variant.
 - Headless invocation pattern per worker:
   `$OMP_BIN --allow-home -p --permission-mode bypassPermissions --no-session-persistence --strict-mcp-config --disable-slash-commands --config "$NO_ADVISOR_CFG" [--model <L1_MODEL>]`
-- Tools grant: keep `--tools Read Write` (L1) and `--tools Glob Read Write Edit` (L2) if omp accepts the same flag; if omp rejects `--tools`, drop it (L1/L2 already get a scoped tool surface via system prompt).
+- Tools grant: L1 workers get `--tools=Read,Write` (read the transcript, write the findings JSON); the L2 aggregator gets `--tools=Glob,Read` — no Write/Edit, because L2 emits the report on stdout only and must never touch files. Both flags are accepted by omp.
 
 ## Advisor-off overlay (REQUIRED on every worker)
 - File: `$AUTODREAM_DIR/l1-no-advisor.yml` (written by install.sh), content:
@@ -34,8 +34,9 @@ Cross-slice interfaces for porting cc-autodream to OMP. All slices agree on thes
 - User-turn timestamps: from the record's own `timestamp` field (ISO).
 - Sidechain/subagent: OMP marks subagent transcripts — use custom_type markers; default `isSidechain:false` unless a `custom` record signals subagent (e.g. `agent`/`subagent` custom types). Keep bias-to-triage on unknown.
 
-## Findings/reports/state — UNCHANGED by the port
-- `findings/<date>/`, `dreams/<date>.md`, `notes.md`, `inbox/`, `run-stats.txt`, report-complete marker `autodream:open-questions=`, L1 idempotency (findings JSON with `.findings` key), retry rounds, SIGPIPE hardening, consume gates. Port does NOT touch these.
+## Findings/reports/state
+- `findings/<date>/`, `dreams/<date>.md`, `notes.md`, `inbox/`, `run-stats.txt`, report-complete marker `autodream:open-questions=`, L1 idempotency (findings JSON with `.findings` key), retry rounds, SIGPIPE hardening, consume gates. The port keeps all of these.
+- L2 report delivery changed: the aggregator has NO Write tool. It prints the report on stdout ending with an `AUTODREAM_REPORT_END` line; run.sh strips everything from the LAST sentinel into `dreams/<date>.md` (atomic tmp+rename) and appends the post-sentinel `report:` + 3-line summary to the run log. A capture is a validated delivery only with the sentinel present AND the `autodream:open-questions=` marker.
 
 ## L1/L2 models
 - L1: `runinfra/deepseek-v4-flash` (env `AUTODREAM_L1_MODEL`, default that).

--- a/bin/skills-inventory.sh
+++ b/bin/skills-inventory.sh
@@ -245,16 +245,21 @@ already_emitted() {                                  # $1=name ; first occurrenc
 }
 
 scan_skill() {                                       # $1=path to SKILL.md ; emit if active
-  local s="$1" name
+  local s="$1" name dir_name
   [ -f "$s" ] || return 0
   read_frontmatter "$s"
   [ "$FM_ENABLED" = 1 ] || return 0
+  dir_name="$(basename "$(dirname "$s")")"
   name="$FM_NAME"
   case "$name" in
     ">"|">-"|"|"|"|-") name="" ;;
   esac
-  [ -n "$name" ] || name="$(basename "$(dirname "$s")")"
+  [ -n "$name" ] || name="$dir_name"
+  # A skill is disabled when its resolved name OR its on-disk directory name is in
+  # skills.ignoredSkills: an operator disables by whichever spelling they see, and a
+  # skill's frontmatter `name:` routinely differs from the directory it lives in.
   in_ignored "$name" && return 0
+  [ "$name" != "$dir_name" ] && in_ignored "$dir_name" && return 0
   already_emitted "$name" && return 0
   emitted="$emitted
 $name"
@@ -290,10 +295,12 @@ tmpfile="$(mktemp "$outdir/skills-inventory.XXXXXX" 2>/dev/null)" || {
     done
     if [ -d "$bucket/plugins" ]; then
       # Plugin skills live at arbitrary depth; `find` + `-path` beats a `*` glob that
-      # cannot cross `/`.
+      # cannot cross `/`. No `-maxdepth` cap: the `*/skills/*/SKILL.md` path shape
+      # already bounds the result set, and a fixed cap silently drops deeper skills
+      # (measured: 4 plugin SKILL.md nested one level past an `-maxdepth 8` cut).
       while IFS= read -r s; do
         scan_skill "$s"
-      done < <(find "$bucket/plugins" -maxdepth 8 -path '*/skills/*/SKILL.md' -type f 2>/dev/null)
+      done < <(find "$bucket/plugins" -path '*/skills/*/SKILL.md' -type f 2>/dev/null)
     fi
   done
 } > "$tmpfile"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1849,6 +1849,7 @@ test_skills_inventory(){
     '  ignoredSkills:' \
     '    - alpha # documented off' \
     '    - "betaquoted"' \
+    '    - renamed-here' \
     '' \
     '    - gamma' \
     '  toolAllow:' \
@@ -1860,7 +1861,9 @@ test_skills_inventory(){
     "$SK/alpha" "$SK/betaquoted" "$SK/gamma" "$SK/delta" "$SK/off-skill" \
     "$SK/folded-desc" "$SK/block-name" "$SK/dirname-fallback" \
     "$SK/commented-name" "$SK/block-no-value" \
+    "$SK/renamed-here" \
     "$T/home/.claude/plugins/someplugin/skills/plgsku" \
+    "$T/home/.claude/plugins/p1/p2/p3/p4/p5/p6/skills/deep-skill" \
     "$T/home/.claude-ds4/skills/shared-skill" \
     "$T/home/.agents/skills/shared-dup" \
     "$T/home/.config/opencode/skills/oc-skill" \
@@ -1879,6 +1882,15 @@ test_skills_inventory(){
   printf '%s\n' '---' 'name: >-' 'description: survives the name swallow' '---' > "$SK/block-no-value/SKILL.md"
   printf '%s\n' '---' 'name: plgsku' 'description: nested plugin skill' '---' \
     > "$T/home/.claude/plugins/someplugin/skills/plgsku/SKILL.md"
+  # A plugin skill sitting at depth 9 from the plugins root: the old -maxdepth 8 cap
+  # silently dropped files past it, so this must still be found.
+  printf '%s\n' '---' 'name: deep-skill' 'description: far below the plugins root' '---' \
+    > "$T/home/.claude/plugins/p1/p2/p3/p4/p5/p6/skills/deep-skill/SKILL.md"
+  # Excluded by on-disk DIRECTORY name: the ignore list names the dir the operator
+  # sees, and this skill's frontmatter name differs from its directory — the
+  # exclusion must still apply.
+  printf '%s\n' '---' 'name: actual-name' 'description: dir-name ignored' '---' \
+    > "$SK/renamed-here/SKILL.md"
   printf '%s\n' '---' 'name: shared-skill' 'description: from the ds4 bucket' '---' \
     > "$T/home/.claude-ds4/skills/shared-skill/SKILL.md"
   printf '%s\n' '---' 'name: shared-skill' 'description: from the agents root' '---' \
@@ -1910,6 +1922,8 @@ test_skills_inventory(){
   assert_grep   "$T/out.txt" '^triage\tfrontmatter comments stripped$' "inline comments are stripped from name and description"
   assert_grep   "$T/out.txt" '^block-no-value\tsurvives the name swallow$' "an empty block-scalar name falls back to dirname and does not swallow the next key"
   assert_grep   "$T/out.txt" '^plgsku\t' "plugin skill found under plugins/"
+  assert_grep   "$T/out.txt" '^deep-skill\t' "a plugin skill at depth 9 (past the old -maxdepth 8 cap) is found"
+  assert_nogrep "$T/out.txt" '^actual-name\t' "a skill whose on-disk directory name is in ignoredSkills is excluded even when its frontmatter name differs"
   assert_grep   "$T/out.txt" '^oc-skill\t' "opencode root skill listed"
   assert_grep   "$T/out.txt" '^mang\t' "OMP managed-root skill listed"
 


### PR DESCRIPTION
Closes the leftover sub-80 findings from the `/code-review` fanout on PR #3: a stale L2 tool grant in `PORT_CONTRACT.md`, and two real defects in `skills-inventory.sh` (a `-maxdepth 8` cap that silently dropped 4 plugin skills, and `ignoredSkills` matching only the frontmatter name when operators disable by directory name).

- `PORT_CONTRACT.md`: L2 grant corrected to `--tools=Glob,Read` + a new "L2 report delivery" note (stdout + sentinel, no Write).
- `skills-inventory.sh`: plugin scan cap removed (measured 674 → 678 SKILL.md found); a skill is excluded when its resolved name OR its on-disk directory name is in `skills.ignoredSkills`.
- `tests/run-all.sh`: depth-9 plugin fixture (must be found) + renamed-dir fixture (must be excluded). 301/301.

## Status — 2026-08-18

Scorecard: tests 301/301 (run-all), 23/23 (review-skip), bash -n clean; CI green on push.

Open follow-ups: none new. Issue #4 (install.sh `--no-schedule` path mismatch) keeps its remaining run.sh-default half open.

Merge gate: this touches `bin/skills-inventory.sh`, so the repo's `/debate:run tight` requirement nominally applies. Maintainer directed this cleanup as the close-out of the merged PR #3 review; the change is the same already-paneled file, small and test-pinned. Verdict on record from PR #3 stood REVISE (3-round budget exhausted, all findings fixed) — this commit is folded under the same explicit maintainer direction.

## Test plan

- [x] tests/run-all.sh 301/301
- [x] tests/review-skip.sh 23/23
- [x] bash -n clean on changed shells
- [x] live scan: all 4 depth-9 plugin skills present under their real frontmatter names
