### PR TITLE
fix: resolve omp from PATH and known install prefixes

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -13,7 +13,8 @@
 #   FANOUT=4 ./run.sh    # tune L1 parallelism (default 8)
 #
 # Environment overrides (all optional):
-#   OMP_BIN        path to omp CLI                       default: /opt/homebrew/bin/omp
+#   OMP_BIN        path to omp CLI    default: resolved from PATH, then $HOME/.bun/bin,
+#                  /opt/homebrew/bin, /usr/local/bin, $HOME/.local/bin, $HOME/.cargo/bin
 #   NO_ADVISOR_CFG path to the advisor-off yaml passed as --config to every worker
 #                  (keeps the opus advisor from booting on headless runs)
 #                                                        default: $AUTODREAM_DIR/l1-no-advisor.yml
@@ -57,7 +58,10 @@
 
 set -u
 
-OMP_BIN="${OMP_BIN:-/opt/homebrew/bin/omp}"
+# Empty means "not yet resolved" — see resolve_omp_bin below. An explicit OMP_BIN (env or
+# config) always wins; otherwise the binary is discovered at run time rather than assumed
+# to sit in Homebrew's prefix.
+OMP_BIN="${OMP_BIN:-}"
 # PROJECTS_DIR's default is applied here AND its explicit-ness is recorded, because the
 # resolution order is SESSION_ROOTS > PROJECTS_DIR(explicit) > autodetect. `:-` can't
 # tell "unset" from "set to the default", and treating the always-present default as
@@ -285,10 +289,45 @@ fi
 
 mkdir -p "$FINDINGS_DIR" "$DREAMS_DIR" "$LOG_DIR" "$WORK_DIR"
 
-export PATH="$HOME/.cargo/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+# `$HOME/.bun/bin` is here because omp ships via bun as well as Homebrew; a launchd job
+# inherits a minimal PATH, so anything not listed is invisible to the run.
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 cd "$HOME" || exit 1
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+# ---- omp binary resolution ----
+# An explicit OMP_BIN (env or config) always wins. Otherwise: PATH first, so a shim, a
+# version manager or a local build is honoured, then the known install prefixes.
+#
+# Hardcoding one prefix fails closed but fails *nightly*: on a host where omp is a bun
+# install (`$HOME/.bun/bin/omp`) the run aborted at "FATAL: omp not found at
+# /opt/homebrew/bin/omp" on every trigger, and the only symptom is a log nobody reads at
+# 03:45. Discovery costs one `command -v` and a handful of `-x` tests.
+# OMP_BIN_CANDIDATES (colon-separated) replaces BOTH the PATH lookup and the built-in
+# prefixes when set. It exists so the search itself is testable: the built-in list holds
+# absolute host paths, so a "nothing found" test would pass or fail depending on whether
+# the developer's own machine happens to have omp in one of them. It doubles as an escape
+# hatch for an install layout nobody anticipated.
+OMP_BIN_CANDIDATES="${OMP_BIN_CANDIDATES:-}"
+resolve_omp_bin() {
+  local c IFS
+  if [ -n "$OMP_BIN_CANDIDATES" ]; then
+    IFS=:
+    for c in $OMP_BIN_CANDIDATES; do
+      [ -n "$c" ] && [ -x "$c" ] && { printf '%s' "$c"; return 0; }
+    done
+    return 1
+  fi
+  if c="$(command -v omp 2>/dev/null)" && [ -x "$c" ]; then
+    printf '%s' "$c"; return 0
+  fi
+  for c in "$HOME/.bun/bin/omp" "/opt/homebrew/bin/omp" "/usr/local/bin/omp" \
+           "$HOME/.local/bin/omp" "$HOME/.cargo/bin/omp" "/opt/local/bin/omp"; do
+    [ -x "$c" ] && { printf '%s' "$c"; return 0; }
+  done
+  return 1
+}
 
 # Wipe the isolated worker bucket. Claude Code's async AI-title generation writes a
 # one-line `{"type":"ai-title",...}` stub into the launch cwd's session bucket even
@@ -733,9 +772,27 @@ run() {
   log "findings:    $FINDINGS_DIR"
   log "report:      $REPORT_PATH"
   log "fanout:      $FANOUT"
-  log "omp:         $OMP_BIN"
+  # Resolve here, not at parse time: this is after the config file has been sourced (so a
+  # config-set OMP_BIN is honoured) and after PATH is exported (so the PATH search sees
+  # the same prefixes the workers will).
+  if [ -z "$OMP_BIN" ]; then
+    OMP_BIN="$(resolve_omp_bin)" || OMP_BIN=""
+    [ -n "$OMP_BIN" ] && log "omp:         $OMP_BIN (resolved)"
+  else
+    log "omp:         $OMP_BIN (explicit)"
+  fi
 
-  [ -x "$OMP_BIN" ] || { log "FATAL: omp not found at $OMP_BIN (set OMP_BIN)"; exit 1; }
+  # Name what was searched. "not found at <one hardcoded path>" sends a reader looking for
+  # a broken install when the real answer is simply a different prefix.
+  [ -n "$OMP_BIN" ] && [ -x "$OMP_BIN" ] || {
+    if [ -n "$OMP_BIN_CANDIDATES" ]; then
+      log "FATAL: omp not found. Searched OMP_BIN_CANDIDATES: $OMP_BIN_CANDIDATES"
+    else
+      log "FATAL: omp not found. Searched PATH ($PATH) and: \$HOME/.bun/bin, /opt/homebrew/bin, /usr/local/bin, \$HOME/.local/bin, \$HOME/.cargo/bin, /opt/local/bin"
+    fi
+    log "       Set OMP_BIN=/path/to/omp in the environment or $AUTODREAM_CONFIG."
+    exit 1
+  }
 
   # ---- Session roots (which $HOME/.claude*/projects dirs we scan) ----
   probe_roots

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -100,7 +100,10 @@ run_dream(){ # $1=root ; inherits MOCK_MODE/MOCK_CAPTURE_DIR/FANOUT + changelog 
   # depend on) the REAL host's skill tree. A suite that passes or fails on whatever
   # skills happen to be installed locally is not a suite.
   mkdir -p "$1/home"
-  AUTODREAM_CHANGELOG="${AUTODREAM_CHANGELOG:-0}" OMP_BIN="$MOCK" \
+  # `${OMP_BIN-...}` (no colon) so a test can pass OMP_BIN="" to exercise resolution:
+  # set-but-empty means "resolve", unset still means "use the mock".
+  AUTODREAM_CHANGELOG="${AUTODREAM_CHANGELOG:-0}" OMP_BIN="${OMP_BIN-$MOCK}" \
+  OMP_BIN_CANDIDATES="${OMP_BIN_CANDIDATES-}" \
   AUTODREAM_CONFIG="${AUTODREAM_CONFIG:-$1/autodream/config}" \
   AUTODREAM_CONSUME_DATE="${AUTODREAM_CONSUME_DATE:-$DATE}" \
   AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 AUTODREAM_L1_ROUNDS="${AUTODREAM_L1_ROUNDS:-2}" \
@@ -594,6 +597,59 @@ test_session_stats(){
   rm -rf "$root"
 }
 
+# ---- omp binary resolution ----
+# The default used to be the literal /opt/homebrew/bin/omp, so a host where omp is a bun
+# install aborted every trigger with "FATAL: omp not found at /opt/homebrew/bin/omp".
+# Discovery now covers PATH and the known prefixes; OMP_BIN stays authoritative.
+#
+# OMP_BIN_CANDIDATES pins the search inside the sandbox. Without it these tests would
+# depend on whether the developer's own machine has omp in one of the absolute prefixes.
+test_omp_bin_resolution(){
+  echo "# omp resolution: explicit wins, discovery finds a bun-style install, absence is named"
+  local root; root=$(setup_env); mk_session "$root" sess1
+
+  # 1. Explicit OMP_BIN is honoured and reported as explicit (run_dream passes the mock).
+  run_dream "$root"
+  assert_grep "$root/run.out" 'omp:.*(explicit)' "an explicit OMP_BIN is used as-is"
+  assert_file "$root/dreams/$DATE.md" "and the run completes"
+
+  # 2. No OMP_BIN: discovery finds it. The candidate path mirrors a bun install, which is
+  #    the layout the hardcoded Homebrew default missed.
+  local root2; root2=$(setup_env); mk_session "$root2" sess1
+  mkdir -p "$root2/home/.bun/bin"; cp "$MOCK" "$root2/home/.bun/bin/omp"
+  OMP_BIN="" OMP_BIN_CANDIDATES="$root2/home/.bun/bin/omp" run_dream "$root2"
+  assert_grep "$root2/run.out" 'omp:.*\.bun/bin/omp (resolved)' "discovery finds a bun-style install"
+  assert_file "$root2/dreams/$DATE.md" "and the run completes on the resolved binary"
+
+  # 3. Nothing anywhere: fail closed, and say what was searched rather than naming one path.
+  local root3; root3=$(setup_env); mk_session "$root3" sess1
+  OMP_BIN="" OMP_BIN_CANDIDATES="$root3/nowhere/omp" run_dream "$root3"
+  assert_grep  "$root3/run.out" 'FATAL: omp not found' "a missing omp still fails closed"
+  assert_grep  "$root3/run.out" 'Searched OMP_BIN_CANDIDATES' "the failure names what it searched"
+  assert_grep  "$root3/run.out" 'Set OMP_BIN=' "and how to fix it"
+  assert_no_file "$root3/dreams/$DATE.md" "no report is produced without an engine"
+
+  # 4. A config-set OMP_BIN is honoured, i.e. resolution runs after the config is sourced.
+  #    This one cannot go through run_dream: the config loader re-applies an `export -p`
+  #    snapshot after sourcing, so an EXPORTED OMP_BIN — even an empty one — deliberately
+  #    beats the config file. Expressing "the environment is silent" therefore requires
+  #    the variable to be genuinely unset, hence `env -u`.
+  local root4; root4=$(setup_env); mk_session "$root4" sess1
+  printf 'OMP_BIN=%s\n' "$MOCK" > "$root4/autodream/config"
+  mkdir -p "$root4/home"
+  env -u OMP_BIN \
+      OMP_BIN_CANDIDATES="$root4/nowhere/omp" \
+      AUTODREAM_CHANGELOG=0 AUTODREAM_CONFIG="$root4/autodream/config" \
+      AUTODREAM_CONSUME_DATE="$DATE" AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 \
+      AUTODREAM_L1_ROUNDS=2 PROJECTS_DIR="$root4/projects" HOME="$root4/home" \
+      AUTODREAM_DIR="$root4/autodream" DREAMS_DIR="$root4/dreams" \
+      bash "$RUN" "$DATE" > "$root4/run.out" 2>&1
+  cat "$root4/autodream/logs/run-$DATE.log" >> "$root4/run.out" 2>/dev/null || true
+  assert_grep "$root4/run.out" 'omp:.*mock' "a config-set OMP_BIN is honoured over discovery"
+  assert_file "$root4/dreams/$DATE.md" "and the run completes"
+
+  rm -rf "$root" "$root2" "$root3" "$root4"
+}
 test_happy(){
   echo "# happy path"
   local root; root=$(setup_env); mk_session "$root" sess1
@@ -1638,6 +1694,7 @@ test_overlap_not_measured_malformed_output(){
 
 echo "cc-autodream integration tests (mock claude)"
 echo
+test_omp_bin_resolution
 test_happy
 test_session_stats
 test_unreadable


### PR DESCRIPTION
Fixes the scheduler-host failure caused by a Homebrew-only `OMP_BIN` default.

## Problem

`bin/run.sh` set:

```sh
OMP_BIN="${OMP_BIN:-/opt/homebrew/bin/omp}"
```

On a bun install, `omp` lives at `$HOME/.bun/bin/omp`. The runner's own launchd PATH did not include that prefix either, so every trigger died before enumeration:

```
FATAL: omp not found at /opt/homebrew/bin/omp (set OMP_BIN)
```

The failure says "not found at <one path>", sending the reader toward a broken install when the actual problem is simply that the binary came from a different supported installer.

## Change

Resolve at run time, *after* config sourcing and PATH setup:

1. Explicit `OMP_BIN` from environment or config — authoritative.
2. `command -v omp`.
3. Known prefixes: `$HOME/.bun/bin`, Homebrew, `/usr/local`, `$HOME/.local`, Cargo, MacPorts.

`$HOME/.bun/bin` is added to the runner's launchd PATH too.

`OMP_BIN_CANDIDATES` is a colon-separated override for a nonstandard layout; it replaces both the PATH lookup and built-in prefixes. It is primarily a deterministic test seam: absolute host prefixes otherwise make a "nothing found" test pass or fail according to a contributor's own installation, but it is also a useful escape hatch for unknown package-manager layouts.

Missing binary remains fail-closed, now with the full searched locations and the exact config/env remedy.

## Verification

- **311 tests, 0 failures** (301 baseline + 10 new resolver assertions).
  - explicit path wins;
  - discovery finds a bun-style install;
  - missing engine fails closed and names the search/fix;
  - config-set `OMP_BIN` works when the environment is genuinely unset (the config loader intentionally restores exported env after sourcing, so exported-empty correctly beats config).
- Shellcheck clean at project CI severities.
- Real-host smoke, `OMP_BIN` genuinely unset: resolved `/Users/sean/.bun/bin/omp` and reached session scanning. The unmodified runner stopped before scanning at `/opt/homebrew/bin/omp`.

No behaviour change for Homebrew installs or explicit `OMP_BIN` users.
