### PR TITLE
feat: AUTODREAM_L1_ONLY — stop after L1 so one aggregation can cover both harnesses

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -14,6 +14,8 @@
 #
 # Environment overrides (all optional):
 #   OMP_BIN        path to omp CLI                       default: /opt/homebrew/bin/omp
+#   AUTODREAM_L1_ONLY  set 1 to stop after L1: findings + run-stats are written, L2 is
+#                  skipped, nothing is consumed, exit 0                       default: 0
 #   NO_ADVISOR_CFG path to the advisor-off yaml passed as --config to every worker
 #                  (keeps the opus advisor from booting on headless runs)
 #                                                        default: $AUTODREAM_DIR/l1-no-advisor.yml
@@ -715,6 +717,10 @@ unassembled_dates() {
     # Findings JSONs only. A dir holding nothing but *.stats.json sidecars was never
     # triaged, so it has nothing to assemble and is not a failure.
     found=$(find "$d" -maxdepth 1 -type f -name '*.json' ! -name '*.stats.json' 2>/dev/null | head -1)
+    # An L1-only run leaves findings and no report on purpose, and says so with a marker.
+    # Without this the warning fires every night on a host that splits triage from
+    # aggregation, which is how a real warning gets trained into background noise.
+    [ -f "$d/l1-only" ] && continue
     [ -n "$found" ] || continue
     report="$DREAMS_DIR/$date_label.md"
     if [ -s "$report" ] && grep -q 'autodream:open-questions=' "$report" 2>/dev/null; then
@@ -1113,6 +1119,35 @@ PY
   [ -x "$skills_inv" ] || skills_inv="$AUTODREAM_DIR/skills-inventory.sh"
   "$skills_inv" "$FINDINGS_DIR/skills-inventory.txt" 2>/dev/null \
     || printf '# skills-inventory.txt unavailable\n' > "$FINDINGS_DIR/skills-inventory.txt"
+
+  # ---- L1-only: stop here, deliberately, with everything L2 would need on disk ----
+  # This install triages OMP sessions; a Claude install triages Claude sessions. When both
+  # run on one host, the useful division is that each does its own L1 and ONE aggregation
+  # runs over the union — otherwise both pay for an L2 whose report nobody reads, and a
+  # pattern with evidence in both harnesses is split across two reports where neither can
+  # see it. This is the seam for that (see #11).
+  #
+  # Placed after the L2 *inputs* are assembled (findings, run-stats, changelog window,
+  # operator notes, bookmarks, skills inventory) so the findings dir is a complete
+  # aggregation package, and before anything that acts on a report — in particular before
+  # the stale-report move below, which would rename a good report aside for a replacement
+  # this run is never going to write.
+  #
+  # Nothing is consumed: the vault-notes archive, the x-bookmark mark-read and the
+  # open-questions inbox are all gated on a validated report, so they are skipped by
+  # construction. The marker file records that the missing report was intentional, so
+  # unassembled_dates() does not report this date as abandoned every single night.
+  #
+  # AUTODREAM_L2_ATTEMPTS=0 is not a substitute: `seq 1 0` is empty so L2 never runs, but
+  # the run then takes the no-delivery path — WARNING, non-zero exit, and a date that
+  # looks abandoned.
+  if [ "${AUTODREAM_L1_ONLY:-0}" = "1" ]; then
+    : > "$FINDINGS_DIR/l1-only"
+    log "L1-only: findings ready at $FINDINGS_DIR; skipping L2, consuming nothing"
+    log "         assemble with: AUTODREAM_FORCE=1 $AUTODREAM_DIR/run.sh $TARGET_DATE"
+    log "===== autodream end: $(date) ====="
+    return 0
+  fi
 
   # ---- Layer 2: opus aggregate, retried until a validated report lands ----
   # The aggregator call can also die to a mid-run sleep (this is what left exit 1 +

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -594,6 +594,73 @@ test_session_stats(){
   rm -rf "$root"
 }
 
+# ---- L1-only mode ----
+# For a host running two autodream installs (one per harness), the useful division is:
+# each install triages its own sessions, and ONE aggregation runs over the union. Without
+# a way to stop after L1 that costs an extra L2 per install, every night, for reports
+# nobody reads. AUTODREAM_L2_ATTEMPTS=0 almost does it (`seq 1 0` is empty) but then takes
+# the no-report path: warning logged, non-zero exit, and the date looks abandoned.
+test_l1_only_stops_after_findings(){
+  echo "# L1-only: findings land, no report, exit 0"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  AUTODREAM_L1_ONLY=1 run_dream "$root"
+  assert_eq "$(cat "$root/run.exit")" "0" "an intentional stop is not a failure"
+  assert_file    "$(fdir "$root")/$h.json"      "the findings JSON is written"
+  assert_file    "$(fdir "$root")/run-stats.txt" "the self-audit is written"
+  assert_no_file "$root/dreams/$DATE.md"         "no report is produced"
+  assert_grep    "$root/run.out" 'L1-only' "the run says why it stopped"
+  rm -rf "$root"
+}
+
+test_l1_only_consumes_nothing(){
+  echo "# L1-only: no inbox file, nothing archived"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  # A note in the vault inbox is the sharpest probe: the consume gates live after L2, so
+  # returning early must leave it for the run that actually assembles a report.
+  local vault="$root/vault"; mkdir -p "$vault/inbox"
+  printf 'a note for the aggregator\n' > "$vault/inbox/note.md"
+  AUTODREAM_VAULT_DIR="$vault" AUTODREAM_L1_ONLY=1 run_dream "$root"
+  assert_file    "$vault/inbox/note.md" "the vault note stays in the inbox"
+  assert_eq      "$(ls "$root/inbox" 2>/dev/null | wc -l | tr -d ' ')" "0" "no open-questions inbox file"
+  rm -rf "$root"
+}
+
+test_l1_only_date_is_not_reported_abandoned(){
+  echo "# L1-only: an intentionally unassembled date is not flagged as a failure"
+  local root; root=$(setup_env); mk_session "$root" s1
+  # A prior date left by an L1-only run: findings, no report, and the marker that says
+  # the omission was deliberate. Without the marker check this warning would fire every
+  # night on a host that splits triage from aggregation.
+  local prior="$root/autodream/findings/2020-01-01"
+  mkdir -p "$prior"
+  printf '{"session_path":"x","project":"proj-a","findings":[]}\n' > "$prior/aaaaaaaaaaaa.json"
+  : > "$prior/l1-only"
+  run_dream "$root"
+  assert_grep   "$(fdir "$root")/run-stats.txt" 'unassembled_dates: *$' "an L1-only date is not listed"
+  assert_nogrep "$root/run.out" 'findings but no complete report' "and no warning is logged"
+  # Control: the same findings dir WITHOUT the marker is still reported, so the marker is
+  # doing the work rather than the scan having been broken.
+  rm -f "$prior/l1-only" "$root/dreams/$DATE.md"
+  run_dream "$root"
+  assert_grep "$(fdir "$root")/run-stats.txt" 'unassembled_dates: 2020-01-01' "without the marker it is listed"
+  rm -rf "$root"
+}
+
+test_l1_only_then_assemble(){
+  echo "# L1-only: a later normal run assembles the same date without re-triaging"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  AUTODREAM_L1_ONLY=1 run_dream "$root"
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  export MOCK_CALL_LOG="$root/calls.txt"; run_dream "$root"; unset MOCK_CALL_LOG
+  assert_file "$root/dreams/$DATE.md" "the report lands on the assembling run"
+  # MOCK_CALL_LOG records one line per L1 invocation. L1 is idempotent, so the assembling
+  # run must spend no worker on an already-triaged session — that is the entire economic
+  # argument for splitting the phases.
+  assert_nogrep "$root/calls.txt" "$h" "no L1 worker ran for the already-triaged session"
+  rm -rf "$root"
+}
+
 test_happy(){
   echo "# happy path"
   local root; root=$(setup_env); mk_session "$root" sess1
@@ -1638,6 +1705,10 @@ test_overlap_not_measured_malformed_output(){
 
 echo "cc-autodream integration tests (mock claude)"
 echo
+test_l1_only_stops_after_findings
+test_l1_only_consumes_nothing
+test_l1_only_date_is_not_reported_abandoned
+test_l1_only_then_assemble
 test_happy
 test_session_stats
 test_unreadable


### PR DESCRIPTION
Adds `AUTODREAM_L1_ONLY=1`: run enumeration and L1, write findings + `run-stats.txt`, skip L2, consume nothing, exit 0.

## Why

On a host running one install per harness, the useful division is *each install triages its own sessions, one aggregation runs over the union*. Without a seam for that, every install pays for an L2 whose report nobody reads, and a pattern with evidence in both harnesses lands split across two reports where neither can rank it. From a merged run over one real day (21 claude + 33 omp sessions):

> `### missed_skill (cross-source: skill invoked once, then agent went manual)`
> **Count**: 2 findings, 2 sessions — **1 claude + 1 omp** (this is the merged-only signal)

## Where the stop sits, and why exactly there

**After** the L2 *inputs* are assembled — findings JSONs, `run-stats.txt`, changelog window, operator notes, bookmarks — so the findings dir is left as a complete aggregation package for whoever assembles it.

**Before** anything that acts on a report. Notably before the stale-report move: that block exists to stop a previous report from being mistaken for this run's output, and running it here would rename a perfectly good report aside for a replacement this run is never going to write.

Everything that consumes input — the vault-notes archive, x-bookmark mark-read, project-memory GC, the open-questions inbox — is already gated on a complete report, so it is skipped by construction rather than by a second check I could get wrong. That is asserted, not assumed: a test drops a note in a vault inbox, runs L1-only, and requires it to still be there (this repo removed the L2 memory-write path in #1, so there is no pin to probe).

## The marker

L1-only writes a `l1-only` file into the findings dir, and `unassembled_dates()` skips dirs that have it. Without this, the "findings but no complete report" warning fires **every night** on precisely the host this feature is for — which is how a real warning gets trained into background noise. The test includes the control: same findings dir with the marker removed is still reported, so the marker is doing the work rather than the scan having been broken.

## Why not `AUTODREAM_L2_ATTEMPTS=0`

It nearly works — `seq 1 0` is empty, so L2 never runs — but the run then takes the no-report path: a WARNING, a non-zero exit, and a date that looks abandoned in the self-audit. Fine for a one-off experiment, wrong for a nightly under launchd.

## Verification

- Suite **313 assertions, 0 failures** (301 baseline + 12 new; each watched failing first).
- `shellcheck --severity=warning bin/*.sh install.sh` and `--severity=error tests/*.sh` clean.
- Tests cover: findings land / no report / exit 0; nothing consumed (vault note survives, no open-questions inbox file); the date is not flagged abandoned, with the negative control; and a later normal run assembles the same date **without re-invoking L1** — asserted via `MOCK_CALL_LOG` on the session hash, which is the economic point of splitting the phases.

Default is off, so single-install behaviour is byte-identical.

The companion change is `STRML/cc-autodream#49`, so both halves of a two-install host can stop after L1. The merge tool that consumes the two findings dirs lives outside both repos and needs nothing further from either.
